### PR TITLE
Canonical URL als Quelle für ContentHash extractor.py

### DIFF
--- a/metadoc/extract/extractor.py
+++ b/metadoc/extract/extractor.py
@@ -69,6 +69,9 @@ class Extractor(object):
   def get_contenthash(self):
     """Generate md5 hash over title and body copy in order to keep track
     of changes made to a text, do diffs if necessary
+    
+    Possible alternative: Hash over Canonical URL, if present.
+    see: https://support.google.com/webmasters/answer/139066?hl=en
     """
     contentstring = (self.title + self.fulltext).encode("utf-8")
     self.contenthash = hashlib.md5(contentstring).hexdigest()


### PR DESCRIPTION
Hi Paul - sehr cool, das Ding. Auch, wenn andere Leute das schon machen - Respekt!